### PR TITLE
add channel-specific recipes

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -22,8 +22,14 @@ node.default['apt-chef'].tap do |apt|
   # The base URI for the repository, must be a string
   apt['uri']                 = 'https://packagecloud.io/chef/stable/ubuntu/'
 
-  # Location for the GPG key used to sign the repository
-  apt['key']                 = 'https://packagecloud.io/gpg.key'
+  # Use the local copy of the Chef public GPG key if we're on a Chef Server.
+  # This is to preserve compatibility with the `chef-server-ctl install` command.
+  # Otherwise, retrieve the public key from Chef's downloads page.
+  apt['gpg']         = if File.exist?('/opt/opscode/embedded/keys/packages-chef-io-public.key')
+                         'file:///opt/opscode/embedded/keys/packages-chef-io-public.key'
+                       else
+                         'https://downloads.chef.io/packages-chef-io-public.key'
+                       end
 
   # A list of codenames that are supported for the repository. These
   # are the Ubuntu LTS releases by default, because this is primarily

--- a/recipes/current.rb
+++ b/recipes/current.rb
@@ -1,0 +1,27 @@
+#
+# Cookbook Name:: apt-chef
+# Recipe:: current
+#
+# Author:: Joshua Timberman <joshua@chef.io>
+# Copyright (c) 2015, Chef Software, Inc. <legal@chef.io>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apt_repository 'chef-current' do
+  uri 'https://packagecloud.io/chef/current/ubuntu/'
+  key node['apt-chef']['key']
+  distribution node['apt-chef']['codename']
+  components ['main']
+  trusted true
+end

--- a/recipes/stable.rb
+++ b/recipes/stable.rb
@@ -1,0 +1,27 @@
+#
+# Cookbook Name:: apt-chef
+# Recipe:: stable
+#
+# Author:: Joshua Timberman <joshua@chef.io>
+# Copyright (c) 2015, Chef Software, Inc. <legal@chef.io>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apt_repository 'chef-stable' do
+  uri 'https://packagecloud.io/chef/stable/ubuntu/'
+  key node['apt-chef']['key']
+  distribution node['apt-chef']['codename']
+  components ['main']
+  trusted true
+end


### PR DESCRIPTION
Like https://github.com/chef-cookbooks/yum-chef/pull/3, this adds
channel-specific recipes, this time for apt.

Also, bring over the `gpg` key logic used in the yum cookbook because
it's far better than using the gpg key from packagecloud.

cc: @chef-cookbooks/engineering-services 
