### PR TITLE
attribute key was corrected to gpg

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,6 +19,9 @@ node.default['apt-chef'].tap do |apt|
   # Set the repository name, must be a string.
   apt['repo_name']           = 'chef-stable'
 
+  # The base URI for the repository, must be a string
+  apt['uri']                 = 'https://packagecloud.io/chef/stable/ubuntu/'
+
   # Use the local copy of the Chef public GPG key if we're on a Chef Server.
   # This is to preserve compatibility with the `chef-server-ctl install` command.
   # Otherwise, retrieve the public key from Chef's downloads page.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -16,6 +16,9 @@
 #
 
 node.default['apt-chef'].tap do |apt|
+  # Set the repository name, must be a string.
+  apt['repo_name']           = 'chef-stable'
+
   # Use the local copy of the Chef public GPG key if we're on a Chef Server.
   # This is to preserve compatibility with the `chef-server-ctl install` command.
   # Otherwise, retrieve the public key from Chef's downloads page.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -16,12 +16,6 @@
 #
 
 node.default['apt-chef'].tap do |apt|
-  # Set the repository name, must be a string.
-  apt['repo_name']           = 'chef-stable'
-
-  # The base URI for the repository, must be a string
-  apt['uri']                 = 'https://packagecloud.io/chef/stable/ubuntu/'
-
   # Use the local copy of the Chef public GPG key if we're on a Chef Server.
   # This is to preserve compatibility with the `chef-server-ctl install` command.
   # Otherwise, retrieve the public key from Chef's downloads page.

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache 2.0'
 description 'Configures apt repository for Chef Software, Inc. products'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.2.0'
+version '0.2.1'
 depends 'apt'
 supports 'ubuntu'
 

--- a/recipes/current.rb
+++ b/recipes/current.rb
@@ -20,7 +20,7 @@
 
 apt_repository 'chef-current' do
   uri 'https://packagecloud.io/chef/current/ubuntu/'
-  key node['apt-chef']['key']
+  key node['apt-chef']['gpg']
   distribution node['apt-chef']['codename']
   components ['main']
   trusted true

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,10 +18,4 @@
 # limitations under the License.
 #
 
-apt_repository node['apt-chef']['repo_name'] do
-  uri node['apt-chef']['uri']
-  key node['apt-chef']['key']
-  distribution node['apt-chef']['codename']
-  components ['main']
-  trusted true
-end
+include_recipe 'apt-chef::stable'

--- a/recipes/stable.rb
+++ b/recipes/stable.rb
@@ -20,7 +20,7 @@
 
 apt_repository 'chef-stable' do
   uri 'https://packagecloud.io/chef/stable/ubuntu/'
-  key node['apt-chef']['key']
+  key node['apt-chef']['gpg']
   distribution node['apt-chef']['codename']
   components ['main']
   trusted true

--- a/recipes/stable.rb
+++ b/recipes/stable.rb
@@ -18,8 +18,8 @@
 # limitations under the License.
 #
 
-apt_repository 'chef-stable' do
-  uri 'https://packagecloud.io/chef/stable/ubuntu/'
+apt_repository node['apt-chef']['repo_name']  do
+  uri node['apt-chef']['uri'] 
   key node['apt-chef']['gpg']
   distribution node['apt-chef']['codename']
   components ['main']


### PR DESCRIPTION
The attribute for 'key' was not being set since it was actually 'gpg'.

Default recipe also wasn't needed and was replicating what was in stable.rb so I just did an include_recipe for stable as default.

include stable.rb as default
remove unused attributes
