### PR TITLE
Fix regression with `gpg` attribute

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,6 @@ env:
   matrix:
   - INSTANCE=default-ubuntu-1204
   - INSTANCE=default-ubuntu-1404
-  - INSTANCE=default-centos-6
-  - INSTANCE=default-centos-7
 
 # Don't `bundle install`
 install: echo "skip bundle install"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -26,7 +26,7 @@ node.default['apt-chef'].tap do |apt|
   # This is to preserve compatibility with the `chef-server-ctl install` command.
   # Otherwise, retrieve the public key from Chef's downloads page.
   apt['gpg'] = if File.exist?('/opt/opscode/embedded/keys/packages-chef-io-public.key')
-                 'file:///opt/opscode/embedded/keys/packages-chef-io-public.key'
+                 nil
                else
                  'https://downloads.chef.io/packages-chef-io-public.key'
                end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,10 @@
 require 'chefspec'
 require 'chefspec/berkshelf'
 
+RSpec.configure do |config|
+  config.color = true
+  config.formatter = 'doc'
+  config.log_level = :fatal
+end
+
 at_exit { ChefSpec::Coverage.report! }

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -7,7 +7,7 @@ describe 'apt-chef::default' do
         node.set['apt-chef'].tap do |apt|
           apt['repo_name'] = 'chef-nightly'
           apt['uri'] = 'https://example.com/chef/nightly/ubuntu'
-          apt['key'] = 'https://example.com/package-public.key'
+          apt['gpg'] = 'https://example.com/package-public.key'
         end
       end.converge(described_recipe)
     end
@@ -34,7 +34,7 @@ describe 'apt-chef::default' do
       expect(chef_run).to add_apt_repository('chef-stable').with(
         repo_name: 'chef-stable',
         uri: 'https://packagecloud.io/chef/stable/ubuntu/',
-        key: 'https://packagecloud.io/gpg.key',
+        key: 'https://downloads.chef.io/packages-chef-io-public.key',
         distribution: 'trusty'
       )
     end


### PR DESCRIPTION
Fixes #6, #7

In commit 50f5fa4, we fixed the recipes to use the right attribute,
gpg instead of key.  However, the logic in the attributes file looks
for /opt/opscode/embedded/keys/packages-chef-io-public.key and sets
the key attribute to that file path. This causes the apt_repository
provider logic to try and use a cookbook_file resource to retrieve
that, which cannot be found. The fix is to set the value to nil if the
key file exists from a Chef Server package, because we know we'll have
the key from a previous installation.

This only manifested when using a recipe with `chef_ingredient
"chef-server"`, and could not be reproduced on a clean `kitchen test`.
