### PR TITLE
[JEX-84] Begin using packages.chef.io APT repo

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,7 +20,7 @@ node.default['apt-chef'].tap do |apt|
   apt['repo_name']           = 'chef-stable'
 
   # The base URI for the repository, must be a string
-  apt['uri']                 = 'https://packagecloud.io/chef/stable/ubuntu/'
+  apt['uri']                 = 'https://packages.chef.io/stable-apt'
 
   # Use the local copy of the Chef public GPG key if we're on a Chef Server.
   # This is to preserve compatibility with the `chef-server-ctl install` command.

--- a/recipes/current.rb
+++ b/recipes/current.rb
@@ -19,7 +19,7 @@
 #
 
 apt_repository 'chef-current' do
-  uri 'https://packagecloud.io/chef/current/ubuntu/'
+  uri 'https://packages.chef.io/current-apt'
   key node['apt-chef']['gpg']
   distribution node['apt-chef']['codename']
   components ['main']

--- a/recipes/stable.rb
+++ b/recipes/stable.rb
@@ -19,7 +19,7 @@
 #
 
 apt_repository 'chef-stable' do
-  uri 'https://packagecloud.io/chef/stable/ubuntu/'
+  uri 'https://packages.chef.io/stable-apt'
   key node['apt-chef']['gpg']
   distribution node['apt-chef']['codename']
   components ['main']

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -33,7 +33,7 @@ describe 'apt-chef::default' do
     it 'renders the apt repository with defaults' do
       expect(chef_run).to add_apt_repository('chef-stable').with(
         repo_name: 'chef-stable',
-        uri: 'https://packagecloud.io/chef/stable/ubuntu/',
+        uri: 'https://packages.chef.io/stable-apt',
         key: 'https://downloads.chef.io/packages-chef-io-public.key',
         distribution: 'trusty'
       )


### PR DESCRIPTION
The existing PackageCloud APT repo has been deprecated. The new APT repos have equivalent versions for all products and should be a drop in replacement. See the following mailing list post for full details:
https://discourse.chef.io/t/we-ve-moved-our-software-distribution-to-packages-chef-io/8001

/cc @chef-cookbooks/engineering-services @tas50 
